### PR TITLE
Fixed #118 and #185, added #106, check for deno.land/x urls in readme, basic auditing

### DIFF
--- a/eggs/src/commands/publish.ts
+++ b/eggs/src/commands/publish.ts
@@ -15,6 +15,7 @@ import {
 import {
   pathExists,
   configExists,
+  readmeExists,
 } from "../utilities/files.ts";
 import {
   getAPIKey,
@@ -91,7 +92,7 @@ export const publish = new Command()
           ),
         );
       }
-      if (!egg.files.some((e) => /^(\.?\/)?README\.md/g.test(e))) {
+      if (!readmeExists()) {
         console.log(
           yellow("No README found at project root, continuing without one..."),
         );

--- a/eggs/src/commands/publish.ts
+++ b/eggs/src/commands/publish.ts
@@ -98,6 +98,23 @@ export const publish = new Command()
         );
       }
 
+      //testing if README has original deno.land/x urls instead of x.nest.land urls
+      //if we add a README location field to the egg config, this needs to be updated
+      try {
+        const readmeContent = decoder.decode(
+          await Deno.readFile(`README.md`),
+        );
+        if (readmeContent.toLowerCase().includes(`://deno.land/x/${ egg.name.toLowerCase() }`)) {
+          console.log(
+            yellow(`Your readme contains old import URLs from your project using deno.land/x/${ egg.name.toLowerCase() }.\nYou can change these to https://x.nest.land/${ egg.name }@VERSION`),
+          );
+        }
+      } catch (e) {
+        console.log(
+          yellow("Could not open the README for url checking..."),
+        );
+      }
+
       //formatting
       if (egg.fmt) {
         const formatProcess = Deno.run({ cmd: ["deno", "fmt"] }),

--- a/eggs/src/utilities/files.ts
+++ b/eggs/src/utilities/files.ts
@@ -13,3 +13,7 @@ export function configExists(): boolean {
     existsSync("egg.yml") ||
     existsSync("egg.yaml");
 }
+
+export function readmeExists(): boolean {
+  return existsSync("README.md");
+}

--- a/eggs/src/utilities/files.ts
+++ b/eggs/src/utilities/files.ts
@@ -14,6 +14,7 @@ export function configExists(): boolean {
     existsSync("egg.yaml");
 }
 
+//if we add a README location field to the egg config, this needs to be updated
 export function readmeExists(): boolean {
   return existsSync("README.md");
 }

--- a/web/package.json
+++ b/web/package.json
@@ -23,6 +23,7 @@
     "sass-loader": "^8.0.2",
     "semver": "^7.3.2",
     "vue": "^2.6.11",
+    "vue-clipboard2": "^0.3.1",
     "vue-code-highlight": "^0.7.4",
     "vue-lodash": "^2.1.2",
     "vue-markdown": "^2.2.4",

--- a/web/src/components/package/PackageDetail.vue
+++ b/web/src/components/package/PackageDetail.vue
@@ -147,7 +147,7 @@
                   <p v-if="noVersion">No version available</p>
                 </div>
                 <div class="panel-block" v-if="!noVersion">
-                  <pre class="is-fullwidth"><code>https://x.nest.land/{{ selectedVersion }}/mod.ts</code></pre>
+                  <pre class="is-fullwidth"><code>https://x.nest.land/{{ selectedVersion }}/{{ entryFile | removeFirstSlash }}</code></pre>
                 </div>
               </nav>
               <nav class="panel">
@@ -213,6 +213,7 @@ export default {
       fileView: false,
       currentFileContent: "",
       currentFileURL: "",
+      entryFile: "",
     };
   },
   props: {
@@ -225,8 +226,11 @@ export default {
       if (!createdAt) return "";
       return moment(String(createdAt)).format("LL");
     },
-    removeSlash(val) {
+    removeSlash (val) {
       return val.replace(new RegExp("/", "g"), "");
+    },
+    removeFirstSlash (val) {
+      return val.replace(new RegExp('/', 'i'), '');
     },
   },
   async created() {
@@ -406,7 +410,10 @@ export default {
             this.selectedVersion.split("@")[1]
           }`,
         )
-        .then(response => (this.files = response.data.files));
+        .then(response => {
+          this.files = response.data.files;
+          this.entryFile = response.data.entry;
+        });
     },
     sortPackages(packageList) {
       for (let i = 0; i < packageList.length; i++) {

--- a/web/src/components/package/PackageDetail.vue
+++ b/web/src/components/package/PackageDetail.vue
@@ -150,8 +150,11 @@
                   </div>
                   <p v-if="noVersion">No version available</p>
                 </div>
-                <div class="panel-block" v-if="!noVersion">
-                  <pre class="is-fullwidth"><code>https://x.nest.land/{{ selectedVersion }}/{{ entryFile | removeFirstSlash }}</code></pre>
+                <div class="panel-block entryURL" v-if="!noVersion">
+                  <pre class="is-fullwidth">
+                    <font-awesome-icon :class="{ 'icon-margin-right': true, 'copyEntry': true, copied }" @click="copyPackageEntry" :icon="['fa', (copied ? 'check-square' : 'copy')]" title="Click to copy" />
+                    <code>{{ entryURL }}</code>
+                  </pre>
                 </div>
               </nav>
               <nav class="panel">
@@ -229,6 +232,7 @@ export default {
       currentFileURL: "",
       entryFile: "",
       malicious: false,
+      copied: false,
     };
   },
   props: {
@@ -243,9 +247,6 @@ export default {
     },
     removeSlash (val) {
       return val.replace(new RegExp("/", "g"), "");
-    },
-    removeFirstSlash (val) {
-      return val.replace(new RegExp('/', 'i'), '');
     },
   },
   async created() {
@@ -381,6 +382,10 @@ export default {
 
       return this.currentFileContent.split(/\r\n|\r|\n/).length;
     },
+    entryURL() {
+      const entryFileWithoutFirstSlash = this.entryFile.replace(new RegExp('/', 'i'), '');
+      return `https://x.nest.land/${ this.selectedVersion }/${ entryFileWithoutFirstSlash }`;
+    },
   },
   methods: {
     async refreshContent() {
@@ -481,6 +486,12 @@ export default {
       if (!(this.filesLocation in this.files) && !dirExists)
         this.$router.push(`/404`);
     },
+    copyPackageEntry() {
+      this.$copyText(this.entryURL)
+        .then(() => {
+          this.copied = true
+        });
+    },
   },
   watch: {
     async $route() {
@@ -552,6 +563,23 @@ pre.is-fullwidth {
 .panel-block.warning {
   color: #ff0000;
   font-weight: 600;
+}
+.panel-block.entryURL pre {
+  display: flex;
+  align-items: center;
+  svg {
+    margin-right: 15px;
+    &.copied {
+      color: #00947e;
+    }
+  }
+}
+.panel-block .copyEntry {
+  cursor: pointer;
+  transition: all .3s;
+  &:hover {
+    opacity: .73;
+  }
 }
 .Markdown {
   :first-child {

--- a/web/src/components/package/PackageDetail.vue
+++ b/web/src/components/package/PackageDetail.vue
@@ -177,6 +177,19 @@
                   Published on: {{ packageInfo.createdAt | formatDate }}
                 </div>
               </nav>
+              <nav class="panel">
+                <p class="panel-heading">
+                  <font-awesome-icon class="icon-margin-right" :icon="['fas', 'shield-alt']" />Audit
+                </p>
+                <div class="panel-block" v-if="malicious">
+                  <font-awesome-icon class="icon-margin-right" :icon="['fa', 'biohazard']" />
+                  Malicious module: use at your own risk
+                </div>
+                <div class="panel-block" v-else>
+                  <font-awesome-icon class="icon-margin-right" :icon="['fa', 'lock']" />
+                  The module is safe
+                </div>
+              </nav>
             </div>
           </div>
         </div>
@@ -214,6 +227,7 @@ export default {
       currentFileContent: "",
       currentFileURL: "",
       entryFile: "",
+      malicious: false,
     };
   },
   props: {
@@ -413,6 +427,7 @@ export default {
         .then(response => {
           this.files = response.data.files;
           this.entryFile = response.data.entry;
+          this.malicious = response.data.malicious;
         });
     },
     sortPackages(packageList) {

--- a/web/src/components/package/PackageDetail.vue
+++ b/web/src/components/package/PackageDetail.vue
@@ -26,6 +26,10 @@
                 <p class="subtitle">{{ packageInfo.description }}</p>
                 <hr class="mini-hr" />
               </div>
+              <div class="Warning" v-if="malicious">
+                <font-awesome-icon :icon="['fa', 'exclamation-triangle']"/>
+                <p>This package is flagged as <b>malicious</b>. Do not use it in your projects!</p>
+              </div>
               <vue-markdown
                 :source="packageReadme"
                 :toc="true"
@@ -177,17 +181,14 @@
                   Published on: {{ packageInfo.createdAt | formatDate }}
                 </div>
               </nav>
-              <nav class="panel">
+              <!-- when we add more audit functions like permissions, we need to remove the v-if="malicious" from here and move it to the flagged as malicious panel-block -->
+              <nav class="panel" v-if="malicious">
                 <p class="panel-heading">
                   <font-awesome-icon class="icon-margin-right" :icon="['fas', 'shield-alt']" />Audit
                 </p>
-                <div class="panel-block" v-if="malicious">
+                <div class="panel-block warning">
                   <font-awesome-icon class="icon-margin-right" :icon="['fa', 'biohazard']" />
-                  Malicious module: use at your own risk
-                </div>
-                <div class="panel-block" v-else>
-                  <font-awesome-icon class="icon-margin-right" :icon="['fa', 'lock']" />
-                  The module is safe
+                  Flagged as malicious
                 </div>
               </nav>
             </div>
@@ -512,6 +513,45 @@ export default {
 }
 pre.is-fullwidth {
   width: 100%;
+}
+.Warning {
+  margin-bottom: 20px;
+  border-radius: 6px;
+  box-shadow: 0 0.5em 1em -.125em rgba(10, 10, 10, .1), 0 0px 0 1px rgba(10, 10, 10, .02);
+  background-color: #ededed;
+  padding: 14px 27px;
+  display: flex;
+  align-items: center;
+  border-left: 5px solid #ff0000;
+  b {
+    color: #ff0000;
+  }
+  svg {
+    display: block;
+    font-size: 2em;
+    padding-right: .8em;
+    width: auto !important;
+    color: #ff0000;
+  }
+  &.Info {
+    border-color: #00947e;
+    b {
+      color: #00947e;
+    }
+    svg {
+      color: #00947e;
+    }
+  }
+  p {
+    margin: 0;
+    a {
+      color: #00947e;
+    }
+  }
+}
+.panel-block.warning {
+  color: #ff0000;
+  font-weight: 600;
 }
 .Markdown {
   :first-child {

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -30,6 +30,9 @@ import {
   faUser,
   faCalendarAlt,
   faImage,
+  faShieldAlt,
+  faBiohazard,
+  faLock,
 } from "@fortawesome/free-solid-svg-icons";
 import { faGithub } from "@fortawesome/free-brands-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
@@ -54,6 +57,9 @@ library.add(
   faUser,
   faCalendarAlt,
   faImage,
+  faShieldAlt,
+  faBiohazard,
+  faLock,
 );
 
 Vue.component("font-awesome-icon", FontAwesomeIcon);

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -4,6 +4,7 @@ import { routes } from "./routes";
 import { VueReCaptcha } from "vue-recaptcha-v3";
 import VueLodash from "vue-lodash";
 import lodash from "lodash";
+import VueClipboard from "vue-clipboard2";
 
 import App from "./App.vue";
 import NestFooter from "./components/Footer";
@@ -34,6 +35,8 @@ import {
   faBiohazard,
   faLock,
   faExclamationTriangle,
+  faCopy,
+  faCheckSquare,
 } from "@fortawesome/free-solid-svg-icons";
 import { faGithub } from "@fortawesome/free-brands-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
@@ -62,6 +65,8 @@ library.add(
   faBiohazard,
   faLock,
   faExclamationTriangle,
+  faCopy,
+  faCheckSquare,
 );
 
 Vue.component("font-awesome-icon", FontAwesomeIcon);
@@ -73,6 +78,7 @@ Vue.config.productionTip = false;
 Vue.use(VueRouter);
 Vue.use(VueReCaptcha, { siteKey: "6Lepmf8UAAAAABsjF9Fo0kqzm3_2KcHHM2fX43YH" });
 Vue.use(VueLodash, { lodash: lodash });
+Vue.use(VueClipboard);
 
 const router = new VueRouter({
   routes,

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -33,6 +33,7 @@ import {
   faShieldAlt,
   faBiohazard,
   faLock,
+  faExclamationTriangle,
 } from "@fortawesome/free-solid-svg-icons";
 import { faGithub } from "@fortawesome/free-brands-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
@@ -60,6 +61,7 @@ library.add(
   faShieldAlt,
   faBiohazard,
   faLock,
+  faExclamationTriangle,
 );
 
 Vue.component("font-awesome-icon", FontAwesomeIcon);

--- a/web/vue.config.js
+++ b/web/vue.config.js
@@ -18,9 +18,4 @@ module.exports = {
             .use('raw-loader')
             .loader('raw-loader')
     },
-    devServer: {
-
-        proxy: "https://nest.land"
-
-    }
 };

--- a/web/vue.config.js
+++ b/web/vue.config.js
@@ -18,4 +18,9 @@ module.exports = {
             .use('raw-loader')
             .loader('raw-loader')
     },
+    devServer: {
+
+        proxy: "https://nest.land"
+
+    }
 };

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -2300,6 +2300,15 @@ cli-width@^2.0.0:
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.1.tgz#b0433d0b4e9c847ef18868a4ef16fd5fc8271c48"
   integrity sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==
 
+clipboard@^2.0.0:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-2.0.6.tgz#52921296eec0fdf77ead1749421b21c968647376"
+  integrity sha512-g5zbiixBRk/wyKakSwCKd7vQXDjFnAMGHoEyBogG/bw9kTD9GvdAvaoRR1ALcEzt3pVKxZR0pViekPMIS0QyGg==
+  dependencies:
+    good-listener "^1.2.2"
+    select "^1.1.2"
+    tiny-emitter "^2.0.0"
+
 clipboardy@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/clipboardy/-/clipboardy-2.3.0.tgz#3c2903650c68e46a91b388985bc2774287dba290"
@@ -2999,6 +3008,11 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
+
+delegate@^3.1.2:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/delegate/-/delegate-3.2.0.tgz#b66b71c3158522e8ab5744f720d8ca0c2af59166"
+  integrity sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==
 
 delegates@^1.0.0:
   version "1.0.0"
@@ -4083,6 +4097,13 @@ globule@^1.0.0:
     glob "~7.1.1"
     lodash "~4.17.12"
     minimatch "~3.0.2"
+
+good-listener@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/good-listener/-/good-listener-1.2.2.tgz#d53b30cdf9313dffb7dc9a0d477096aa6d145c50"
+  integrity sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=
+  dependencies:
+    delegate "^3.1.2"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.2:
   version "4.2.4"
@@ -7389,6 +7410,11 @@ select-hose@^2.0.0:
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
   integrity sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=
 
+select@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/select/-/select-1.1.2.tgz#0e7350acdec80b1108528786ec1d4418d11b396d"
+  integrity sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=
+
 selfsigned@^1.10.7:
   version "1.10.7"
   resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-1.10.7.tgz#da5819fd049d5574f28e88a9bcc6dbc6e6f3906b"
@@ -8179,6 +8205,11 @@ timsort@^0.3.0:
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
 
+tiny-emitter@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
+  integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -8570,6 +8601,13 @@ vm-browserify@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
+
+vue-clipboard2@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/vue-clipboard2/-/vue-clipboard2-0.3.1.tgz#6e551fb7bd384889b28b0da3b12289ed6bca4894"
+  integrity sha512-H5S/agEDj0kXjUb5GP2c0hCzIXWRBygaWLN3NEFsaI9I3uWin778SFEMt8QRXiPG+7anyjqWiw2lqcxWUSfkYg==
+  dependencies:
+    clipboard "^2.0.0"
 
 vue-code-highlight@^0.7.4:
   version "0.7.4"


### PR DESCRIPTION
Changes:
- [x] Fixed issue #118. The publish command now actually checks if a readme file is present instead of testing in the files array
- [x] Fixed issue #185 and #67. The website now shows the correct entry file
- [x] Added feature #106. (copy import/entry url)
- [x] Added checking for deno.land/x urls in readme. If an "old import url" (an url with deno.land/x/MOD_NAME) is found, it will warn the user that they can change it to x.nest.land/MOD_NAME...
- [x] Basic auditing. Added auth panel, malicious package display. TODO (not in this PR): more auditing, permissions, warnings
