### PR TITLE
fix: upgrade command not fetching latest version

### DIFF
--- a/eggs/src/commands/install.ts
+++ b/eggs/src/commands/install.ts
@@ -11,6 +11,7 @@ import {
   getLatestVersion,
   analyzeURL,
   globalModulesConfigPath,
+  version,
 } from "../deps.ts";
 
 const installPrefix = "eggs--";
@@ -46,7 +47,7 @@ The installation root is determined, in order of precedence:
 These must be added to the path manually if required.`;
 
 export const install = new Command()
-  .version("0.1.0")
+  .version(version)
   .description(desc)
   .arguments("[OPTIONS...:string]")
   .option("-A, --allow-all", "Allow all permissions")

--- a/eggs/src/commands/upgrade.ts
+++ b/eggs/src/commands/upgrade.ts
@@ -5,6 +5,7 @@ import {
   bold,
   path,
   version,
+  getLatestVersionFromNestRegistry,
 } from "../deps.ts";
 
 export const upgrade = new Command()
@@ -20,7 +21,7 @@ export const upgrade = new Command()
         "-f",
         "-n",
         "eggs",
-        `https://x.nest.land/eggs@${version}/mod.ts`,
+        `https://x.nest.land/eggs@${await getLatestVersionFromNestRegistry("eggs")}/mod.ts`,
       ],
       stdout: "piped",
       stderr: "piped",

--- a/eggs/src/deps.ts
+++ b/eggs/src/deps.ts
@@ -8,6 +8,6 @@ export { assertEquals, assertMatch, assert } from "https://deno.land/std@v0.56.0
 export { parse, stringify } from "https://deno.land/std@0.56.0/encoding/yaml.ts";
 export * as base64 from "https://denopkg.com/chiefbiiko/base64@v0.2.0/mod.ts";
 export { installUpdateHandler, globalModulesConfigPath } from "https://x.nest.land/eggs-update-handler@0.5.1/mod.ts";
-export { getLatestVersion, analyzeURL, versionSubstitute } from "https://x.nest.land/eggs-update-handler@0.5.1/lib/registries.ts";
-export { version } from "https://raw.githubusercontent.com/nestlandofficial/nest.land/master/eggs/src/version.ts";
+export { getLatestVersionFromNestRegistry, getLatestVersion, analyzeURL, versionSubstitute } from "https://x.nest.land/eggs-update-handler@0.5.1/lib/registries.ts";
+export { version } from "./version.ts";
 export const lstatSync = Deno.lstatSync;


### PR DESCRIPTION
reported by @Qu4k

the upgrade command would fetch the version from the `version.ts` file on the remote repo which was also used to display the current version in the help menu.

so if the `version.ts` was cached, the upgrade command won't work. And if it wasn't cached, the help menu would show the wrong version, given eggs is not on the latest version.

fix:

use the nest.land api to fetch the latest version and use local file to fetch the current version.

P.S. also fixed hardcoded version in the install command 