### PR TITLE
wip(api + web): use yolk for api calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@fortawesome/free-brands-svg-icons": "^5.13.0",
     "@fortawesome/free-solid-svg-icons": "^5.13.0",
     "@fortawesome/vue-fontawesome": "^0.1.9",
-    "@nestdotland/yolk": "^0.2.0",
+    "@nestdotland/yolk": "^0.2.0-rc1",
     "axios": "^0.19.2",
     "babel-runtime": "^6.26.0",
     "bulma": "^0.8.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "@fortawesome/free-brands-svg-icons": "^5.13.0",
     "@fortawesome/free-solid-svg-icons": "^5.13.0",
     "@fortawesome/vue-fontawesome": "^0.1.9",
-    "@nestdotland/yolk": "^0.2.0-rc1",
     "axios": "^0.19.2",
     "babel-runtime": "^6.26.0",
     "bulma": "^0.8.2",
@@ -30,7 +29,8 @@
     "vue-lodash": "^2.1.2",
     "vue-markdown": "^2.2.4",
     "vue-recaptcha-v3": "^1.9.0",
-    "vue-router": "^3.3.1"
+    "vue-router": "^3.3.1",
+    "@nestdotland/yolk": "^0.3.0"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "~4.3.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@fortawesome/free-brands-svg-icons": "^5.13.0",
     "@fortawesome/free-solid-svg-icons": "^5.13.0",
     "@fortawesome/vue-fontawesome": "^0.1.9",
-    "@nestdotland/yolk": "^0.1.0-rc.3",
+    "@nestdotland/yolk": "^0.2.0",
     "axios": "^0.19.2",
     "babel-runtime": "^6.26.0",
     "bulma": "^0.8.2",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@fortawesome/free-brands-svg-icons": "^5.13.0",
     "@fortawesome/free-solid-svg-icons": "^5.13.0",
     "@fortawesome/vue-fontawesome": "^0.1.9",
+    "@nestdotland/yolk": "^0.1.0-rc.3",
     "axios": "^0.19.2",
     "babel-runtime": "^6.26.0",
     "bulma": "^0.8.2",

--- a/src/components/package/FileExplorer.vue
+++ b/src/components/package/FileExplorer.vue
@@ -79,6 +79,7 @@
 
 <script>
   import axios from "axios";
+  import * as yolk from "@nestdotland/yolk";
   import VueMarkdown from "vue-markdown";
   import { component as VueCodeHighlight } from "vue-code-highlight";
   import "../../styles/CodeHighlightTheme.sass";
@@ -251,13 +252,14 @@
     methods: {
       //reload the files, and the filesystem on changes
       async reloadFiles () {
-        await axios
-          .get(
-            `https://x.nest.land/api/package/${ this.name }/${
-              this.std ? this.version : this.version.split("@")[1]
-            }`,
-          )
-          .then(response => this.files = response.data.files)
+        // await axios
+         // .get(
+         //   `https://x.nest.land/api/package/${ this.name }/${
+         //     this.std ? this.version : this.version.split("@")[1]
+         //   }`,
+         // )
+           yolk.moduleByName(this.name)
+          .then(response => this.files = response.data.module.uploads[0].files)
           .catch(() => {});
       },
       //load the current file

--- a/src/views/Gallery.vue
+++ b/src/views/Gallery.vue
@@ -85,7 +85,8 @@
 import NestNav from "../components/Nav";
 import GradientBar from "../components/GradientBar";
 import Card from "../components/Card";
-import * as yolk from "@nestdotland/yolk";
+import * as Yolk from "@nestdotland/yolk";
+// TODO: change version to 1.0.0 when published
 
 export default {
   data() {
@@ -97,7 +98,8 @@ export default {
       errorMessage: "",
       loadedPackages: 24,
       loadingPackages: false,
-      noMorePackages: false
+      noMorePackages: false,
+      yolk: new Yolk.Yolk("http://localhost:8080"),
     };
   },
   props: {
@@ -126,7 +128,7 @@ export default {
       this.loadingPackages = true;
       const previousPackagesLength = this.packages.length;
       if (this.search !== "") this.searchPhrase = this.search;
-      yolk.modules()
+      this.yolk.modules()
         .then(response => {
           this.packages = response.data.modules;
           this.shownPackages = this.packages;
@@ -168,7 +170,7 @@ export default {
         this.shownPackages = this.packages;
         return;
       }
-      yolk.modules().then(response => {
+      this.yolk.modules().then(response => {
         console.log(response.data.modules)
         this.shownPackages = response.data.modules.filter(({ name }) =>
           name.toLowerCase().includes(this.searchPhrase.toLowerCase())

--- a/src/views/Gallery.vue
+++ b/src/views/Gallery.vue
@@ -86,6 +86,7 @@ import NestNav from "../components/Nav";
 import GradientBar from "../components/GradientBar";
 import Card from "../components/Card";
 import axios from "axios";
+import yolk from "@nestdotland/yolk";
 
 export default {
   data() {
@@ -126,8 +127,7 @@ export default {
       this.loadingPackages = true;
       const previousPackagesLength = this.packages.length;
       if (this.search !== "") this.searchPhrase = this.search;
-      await axios
-        .get(`https://x.nest.land/api/packages/${this.loadedPackages}`)
+      await yolk.modules(this.loadedPackages)
         .then(response => {
           this.packages = response.data;
           this.shownPackages = this.packages;

--- a/src/views/Gallery.vue
+++ b/src/views/Gallery.vue
@@ -85,8 +85,7 @@
 import NestNav from "../components/Nav";
 import GradientBar from "../components/GradientBar";
 import Card from "../components/Card";
-import axios from "axios";
-import yolk from "@nestdotland/yolk";
+import * as yolk from "@nestdotland/yolk";
 
 export default {
   data() {
@@ -127,7 +126,7 @@ export default {
       this.loadingPackages = true;
       const previousPackagesLength = this.packages.length;
       if (this.search !== "") this.searchPhrase = this.search;
-      await yolk.modules(this.loadedPackages)
+      yolk.modules(this.loadedPackages)
         .then(response => {
           this.packages = response.data;
           this.shownPackages = this.packages;
@@ -169,7 +168,7 @@ export default {
         this.shownPackages = this.packages;
         return;
       }
-      axios.get(`https://x.nest.land/api/packages`).then(response => {
+      yolk.modules().then(response => {
         this.shownPackages = response.data.filter(({ name }) =>
           name.toLowerCase().includes(this.searchPhrase.toLowerCase())
         );

--- a/src/views/Gallery.vue
+++ b/src/views/Gallery.vue
@@ -126,9 +126,9 @@ export default {
       this.loadingPackages = true;
       const previousPackagesLength = this.packages.length;
       if (this.search !== "") this.searchPhrase = this.search;
-      yolk.modules(this.loadedPackages)
+      yolk.modules()
         .then(response => {
-          this.packages = response.data;
+          this.packages = response.data.modules;
           this.shownPackages = this.packages;
           this.loading = false;
           this.loadingPackages = false;
@@ -169,10 +169,11 @@ export default {
         return;
       }
       yolk.modules().then(response => {
-        this.shownPackages = response.data.filter(({ name }) =>
+        console.log(response.data.modules)
+        this.shownPackages = response.data.modules.filter(({ name }) =>
           name.toLowerCase().includes(this.searchPhrase.toLowerCase())
         );
-      });
+      })
     }
   }
 };

--- a/src/views/PackageDetail.vue
+++ b/src/views/PackageDetail.vue
@@ -195,11 +195,11 @@
       //     this.selectedVersion.split("@")[1]
       //    }`,
       //  )
-      console.log(this.packageInfo.name) // outputs "Object"
       yolk.moduleByName(this.packageInfo.name)
       .then(response => {
-        this.malicious = response.data.malicious;
-        if(response.data.entry !== null) this.entryFile = response.data.entry;
+        this.malicious = response.data.module.malicious;
+        console.log(response.data.module)
+        if(response.data.module.entry !== null) this.entryFile = response.data.module.entry;
       });
       await this.refreshReadme();
       this.loading = false;
@@ -269,7 +269,7 @@
       },
       sortPackages(packageList) {
         for (let i = 0; i < packageList.length; i++) {
-          packageList[i] = packageList[i].split("@")[1];
+          packageList[i] = packageList[i].name.split("@")[1];
         }
         return semverSort(packageList).reverse();
       },

--- a/src/views/PackageDetail.vue
+++ b/src/views/PackageDetail.vue
@@ -197,9 +197,9 @@
       //  )
       yolk.moduleByName(this.packageInfo.name)
       .then(response => {
-        this.malicious = response.data.module.malicious;
-        console.log(response.data.module)
-        if(response.data.module.entry !== null) this.entryFile = response.data.module.entry;
+        console.log(response.data.module.uploads[0])
+        this.malicious = response.data.module.uploads[0].malicious;
+        if(response.data.module.uploads[0].entry !== null) this.entryFile = response.data.module.uploads[0].entry;
       });
       await this.refreshReadme();
       this.loading = false;
@@ -222,7 +222,6 @@
             this.$router.push("/404");
             return;
           }
-          console.log(packageDataResponse.data.module)
           this.packageInfo = packageDataResponse.data.module;
           this.packageVersions = this.sortPackages(
             this.packageInfo.uploads,

--- a/yarn.lock
+++ b/yarn.lock
@@ -902,10 +902,115 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
+"@nestdotland/yolk@^0.1.0-rc.3":
+  version "0.1.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@nestdotland/yolk/-/yolk-0.1.0-rc.3.tgz#8b42fb8eb47985d34080ff86161ff350aeb5524e"
+  integrity sha512-6qxCvHQM/XKiXIbYqqCaa+WeZZj/Fz5maxGCLgvBO6DHWfmarHgH/UiFobyx/q5vKUvRHj6sPYbDSKLHKKGURw==
+  dependencies:
+    denoify "^0.3.0"
+    typescript "^3.9.6"
+
 "@nodelib/fs.stat@^1.1.2":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
+
+"@octokit/auth-token@^2.4.0":
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/@octokit/auth-token/-/auth-token-2.4.2.tgz#10d0ae979b100fa6b72fa0e8e63e27e6d0dbff8a"
+  integrity sha512-jE/lE/IKIz2v1+/P0u4fJqv0kYwXOTujKemJMFr6FeopsxlIK3+wKDCJGnysg81XID5TgZQbIfuJ5J0lnTiuyQ==
+  dependencies:
+    "@octokit/types" "^5.0.0"
+
+"@octokit/core@^3.0.0":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@octokit/core/-/core-3.1.1.tgz#1856745aa8fb154cf1544a2a1b82586c809c5e66"
+  integrity sha512-cQ2HGrtyNJ1IBxpTP1U5m/FkMAJvgw7d2j1q3c9P0XUuYilEgF6e4naTpsgm4iVcQeOnccZlw7XHRIUBy0ymcg==
+  dependencies:
+    "@octokit/auth-token" "^2.4.0"
+    "@octokit/graphql" "^4.3.1"
+    "@octokit/request" "^5.4.0"
+    "@octokit/types" "^5.0.0"
+    before-after-hook "^2.1.0"
+    universal-user-agent "^6.0.0"
+
+"@octokit/endpoint@^6.0.1":
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-6.0.5.tgz#43a6adee813c5ffd2f719e20cfd14a1fee7c193a"
+  integrity sha512-70K5u6zd45ItOny6aHQAsea8HHQjlQq85yqOMe+Aj8dkhN2qSJ9T+Q3YjUjEYfPRBcuUWNgMn62DQnP/4LAIiQ==
+  dependencies:
+    "@octokit/types" "^5.0.0"
+    is-plain-object "^4.0.0"
+    universal-user-agent "^6.0.0"
+
+"@octokit/graphql@^4.3.1":
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/@octokit/graphql/-/graphql-4.5.3.tgz#d5ff0d4a8a33e98614a2a7359dac98bc285e062f"
+  integrity sha512-JyYvi3j2tOb5ofASEpcg1Advs07H+Ag+I+ez7buuZfNVAmh1IYcDTuxd4gnYH8S2PSGu+f5IdDGxMmkK+5zsdA==
+  dependencies:
+    "@octokit/request" "^5.3.0"
+    "@octokit/types" "^5.0.0"
+    universal-user-agent "^6.0.0"
+
+"@octokit/plugin-paginate-rest@^2.2.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.3.0.tgz#7d1073e56cfd15d3f99dcfe81fa5d2b466f3a6f6"
+  integrity sha512-Ye2ZJreP0ZlqJQz8fz+hXvrEAEYK4ay7br1eDpWzr6j76VXs/gKqxFcH8qRzkB3fo/2xh4Vy9VtGii4ZDc9qlA==
+  dependencies:
+    "@octokit/types" "^5.2.0"
+
+"@octokit/plugin-request-log@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-request-log/-/plugin-request-log-1.0.0.tgz#eef87a431300f6148c39a7f75f8cfeb218b2547e"
+  integrity sha512-ywoxP68aOT3zHCLgWZgwUJatiENeHE7xJzYjfz8WI0goynp96wETBF+d95b8g/uL4QmS6owPVlaxiz3wyMAzcw==
+
+"@octokit/plugin-rest-endpoint-methods@4.1.2":
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.1.2.tgz#546a8f3e0b514f434a4ad4ef926005f1c81a5a5a"
+  integrity sha512-PTI7wpbGEZ2IR87TVh+TNWaLcgX/RsZQalFbQCq8XxYUrQ36RHyERrHSNXFy5gkWpspUAOYRSV707JJv6BhqJA==
+  dependencies:
+    "@octokit/types" "^5.1.1"
+    deprecation "^2.3.1"
+
+"@octokit/request-error@^2.0.0":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-2.0.2.tgz#0e76b83f5d8fdda1db99027ea5f617c2e6ba9ed0"
+  integrity sha512-2BrmnvVSV1MXQvEkrb9zwzP0wXFNbPJij922kYBTLIlIafukrGOb+ABBT2+c6wZiuyWDH1K1zmjGQ0toN/wMWw==
+  dependencies:
+    "@octokit/types" "^5.0.1"
+    deprecation "^2.0.0"
+    once "^1.4.0"
+
+"@octokit/request@^5.3.0", "@octokit/request@^5.4.0":
+  version "5.4.7"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.4.7.tgz#fd703ee092e0463ceba49ff7a3e61cb4cf8a0fde"
+  integrity sha512-FN22xUDP0i0uF38YMbOfx6TotpcENP5W8yJM1e/LieGXn6IoRxDMnBf7tx5RKSW4xuUZ/1P04NFZy5iY3Rax1A==
+  dependencies:
+    "@octokit/endpoint" "^6.0.1"
+    "@octokit/request-error" "^2.0.0"
+    "@octokit/types" "^5.0.0"
+    deprecation "^2.0.0"
+    is-plain-object "^4.0.0"
+    node-fetch "^2.3.0"
+    once "^1.4.0"
+    universal-user-agent "^6.0.0"
+
+"@octokit/rest@^18.0.0":
+  version "18.0.3"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-18.0.3.tgz#96a15ddb3a38dca5de9d75121378d6aa4a234fa5"
+  integrity sha512-GubgemnLvUJlkhouTM2BtX+g/voYT/Mqh0SASGwTnLvSkW1irjt14N911/ABb6m1Hru0TwScOgFgMFggp3igfQ==
+  dependencies:
+    "@octokit/core" "^3.0.0"
+    "@octokit/plugin-paginate-rest" "^2.2.0"
+    "@octokit/plugin-request-log" "^1.0.0"
+    "@octokit/plugin-rest-endpoint-methods" "4.1.2"
+
+"@octokit/types@^5.0.0", "@octokit/types@^5.0.1", "@octokit/types@^5.1.1", "@octokit/types@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-5.2.0.tgz#d075dc23bf293f540739250b6879e2c1be2fc20c"
+  integrity sha512-XjOk9y4m8xTLIKPe1NFxNWBdzA2/z3PFFA/bwf4EoH6oS8hM0Y46mEa4Cb+KCyj/tFDznJFahzQ0Aj3o1FYq4A==
+  dependencies:
+    "@types/node" ">= 8"
 
 "@soda/friendly-errors-webpack-plugin@^1.7.1":
   version "1.7.1"
@@ -925,6 +1030,11 @@
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
+
+"@types/comment-json@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/comment-json/-/comment-json-1.1.1.tgz#b4ae889912a93e64619f97989aecaff8ce889dca"
+  integrity sha512-U70oEqvnkeSSp8BIJwJclERtT13rd9ejK7XkIzMCQQePZe3VW1b7iQggXyW4ZvfGtGeXD0pZw24q5iWNe++HqQ==
 
 "@types/events@*":
   version "3.0.0"
@@ -949,6 +1059,11 @@
   version "14.0.5"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.5.tgz#3d03acd3b3414cf67faf999aed11682ed121f22b"
   integrity sha512-90hiq6/VqtQgX8Sp0EzeIsv3r+ellbGj4URKj5j30tLlZvRUpnAe9YbYnjl3pJM93GyXU0tghHhvXHq+5rnCKA==
+
+"@types/node@>= 8":
+  version "14.0.27"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.27.tgz#a151873af5a5e851b51b3b065c9e63390a9e0eb1"
+  integrity sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -1745,6 +1860,11 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+before-after-hook@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.1.0.tgz#b6c03487f44e24200dd30ca5e6a1979c5d2fb635"
+  integrity sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==
+
 bfj@^6.1.1:
   version "6.1.2"
   resolved "https://registry.yarnpkg.com/bfj/-/bfj-6.1.2.tgz#325c861a822bcb358a41c78a33b8e6e2086dde7f"
@@ -2434,10 +2554,25 @@ commander@^2.18.0, commander@^2.20.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
+commander@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
+  integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
+
 commander@~2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
   integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
+
+comment-json@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/comment-json/-/comment-json-3.0.2.tgz#a5652a491910e338080bcbf98fc9a37cbd7f3733"
+  integrity sha512-ysJasbJ671+8mPEmwLOfLFqxoGtSmjyoep+lKRVH4J1/hsGu79fwetMDQWk8de8mVgqDZ43D7JuJAlACqjI1pg==
+  dependencies:
+    core-util-is "^1.0.2"
+    esprima "^4.0.1"
+    has-own-prop "^2.0.0"
+    repeat-string "^1.6.1"
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -2593,7 +2728,7 @@ core-js@^3.6.4, core-js@^3.6.5:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
   integrity sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==
 
-core-util-is@1.0.2, core-util-is@~1.0.0:
+core-util-is@1.0.2, core-util-is@^1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
@@ -3019,10 +3154,33 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
+denoify@^0.3.0:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/denoify/-/denoify-0.3.3.tgz#f7d6d21f0ef754c05d12cd54793a554655adc4ed"
+  integrity sha512-QjaaOFYy8bOS9OoQo6nMR67VA0OYXZj1iwMxoH/SA6afFimqH96guN6Hu9d9oqwG8ZDBRVMW5YUwpMPTdlSITA==
+  dependencies:
+    "@octokit/rest" "^18.0.0"
+    "@types/comment-json" "^1.1.1"
+    commander "^4.1.1"
+    comment-json "^3.0.2"
+    evt "^1.7.13"
+    get-github-default-branch-name "^0.0.4"
+    gitignore-parser "0.0.2"
+    glob "^7.1.6"
+    node-fetch "^2.6.0"
+    path-depth "^1.0.0"
+    scripting-tools "^0.19.12"
+    url-join "^4.0.1"
+
 depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
+
+deprecation@^2.0.0, deprecation@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
+  integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
 
 des.js@^1.0.0:
   version "1.0.1"
@@ -3419,7 +3577,7 @@ espree@^6.1.2, espree@^6.2.1:
     acorn-jsx "^5.2.0"
     eslint-visitor-keys "^1.1.0"
 
-esprima@^4.0.0:
+esprima@^4.0.0, esprima@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
@@ -3487,6 +3645,14 @@ evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
   dependencies:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
+
+evt@^1.7.13:
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/evt/-/evt-1.8.3.tgz#720abd318b0bf680b5c734bd1276c1178ff076f5"
+  integrity sha512-3H60tAwOs20WMRbdzodq01cDKNv96ZCr0QKFdxwbkb3ZF+6rhS6eOOXQKdpxdlmJJ/8kIdlArvpdrwx1atBFpw==
+  dependencies:
+    minimal-polyfills "^2.1.3"
+    run-exclusive "^2.2.8"
 
 execa@^0.8.0:
   version "0.8.0"
@@ -3972,6 +4138,14 @@ get-caller-file@^2.0.1:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
+get-github-default-branch-name@^0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/get-github-default-branch-name/-/get-github-default-branch-name-0.0.4.tgz#9c0c6606ba606edb136d2fd26e4d515b69f2de90"
+  integrity sha512-ltOGC9Jk0k8boe48Gk7SkJErwxt7MhwXtbNrBUyNCZcwcXSmGRdkKb2u0YO250PGvPsUtdqRjg7lVuIk1VtpCg==
+  dependencies:
+    "@octokit/rest" "^18.0.0"
+    scripting-tools "^0.19.12"
+
 get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
@@ -4008,6 +4182,11 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
+gitignore-parser@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/gitignore-parser/-/gitignore-parser-0.0.2.tgz#f61259b985dd91414b9a7168faef9171c2eec5df"
+  integrity sha1-9hJZuYXdkUFLmnFo+u+RccLuxd8=
+
 glob-parent@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae"
@@ -4028,7 +4207,7 @@ glob-to-regexp@^0.3.0:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@~7.1.1:
+glob@^7.0.0, glob@^7.0.3, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@~7.1.1:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -4152,6 +4331,11 @@ has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
+has-own-prop@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/has-own-prop/-/has-own-prop-2.0.0.tgz#f0f95d58f65804f5d218db32563bb85b8e0417af"
+  integrity sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ==
 
 has-symbols@^1.0.0, has-symbols@^1.0.1:
   version "1.0.1"
@@ -4820,6 +5004,11 @@ is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
   dependencies:
     isobject "^3.0.1"
+
+is-plain-object@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-4.1.1.tgz#1a14d6452cbd50790edc7fdaa0aed5a40a35ebb5"
+  integrity sha512-5Aw8LLVsDlZsETVMhoMXzqsXwQqr/0vlnBYzIXJbYo2F4yYlhLHs+Ez7Bod7IIQKWkJbJfxrWD7pA1Dw1TKrwA==
 
 is-regex@^1.0.4, is-regex@^1.0.5:
   version "1.0.5"
@@ -5540,6 +5729,11 @@ mini-css-extract-plugin@^0.9.0:
     schema-utils "^1.0.0"
     webpack-sources "^1.1.0"
 
+minimal-polyfills@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/minimal-polyfills/-/minimal-polyfills-2.1.3.tgz#de39bd2cbd18a549b60b6594f1dec602256a5798"
+  integrity sha512-gEbwv2dEvvrGys/hhWdZy+/BGkKAKqzxfmVqmF1Jl9OlD0tK9hEFLJ2tCXOuOtz2qiDMQO2Ke1jYB2s5uCj2Xw==
+
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
@@ -5728,6 +5922,11 @@ no-case@^2.2.0:
   integrity sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==
   dependencies:
     lower-case "^1.1.1"
+
+node-fetch@^2.3.0, node-fetch@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
 
 node-forge@0.9.0:
   version "0.9.0"
@@ -6273,6 +6472,11 @@ path-browserify@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.1.tgz#e6c4ddd7ed3aa27c68a20cc4e50e1a4ee83bbc4a"
   integrity sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==
+
+path-depth@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/path-depth/-/path-depth-1.0.0.tgz#88cf881097e171b8b54d450d2167ea76063d3086"
+  integrity sha512-dEiwdXAQyLvOi6ktLqhFhjVelJiVsdp2xBX3BaUtYCCkMRZTwUiq7cha+A0myvAVXRHbXfjhfTf4mNoAWzm2iA==
 
 path-dirname@^1.0.0:
   version "1.0.2"
@@ -7318,6 +7522,13 @@ run-async@^2.4.0:
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
   integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
 
+run-exclusive@^2.2.8:
+  version "2.2.8"
+  resolved "https://registry.yarnpkg.com/run-exclusive/-/run-exclusive-2.2.8.tgz#106854fff3f9a92a92a365dcaa1bee454e9bd4e0"
+  integrity sha512-WTSUO1p8eLiQGe1v0G1YsmrWt5pRZJHQu/Ql6KbTEqhivhctsyWNKGT+EEnek8l1We5Slm/lV2nqdup1m545Yg==
+  dependencies:
+    minimal-polyfills "^2.1.3"
+
 run-queue@^1.0.0, run-queue@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/run-queue/-/run-queue-1.0.3.tgz#e848396f057d223f24386924618e25694161ec47"
@@ -7396,6 +7607,11 @@ schema-utils@^2.0.0, schema-utils@^2.5.0, schema-utils@^2.6.1, schema-utils@^2.6
   dependencies:
     ajv "^6.12.0"
     ajv-keywords "^3.4.1"
+
+scripting-tools@^0.19.12:
+  version "0.19.12"
+  resolved "https://registry.yarnpkg.com/scripting-tools/-/scripting-tools-0.19.12.tgz#3e63bc396f8f405907191d9982171ecb3d01100f"
+  integrity sha512-EFzjnGAZ/w2jdX8zxV2annB2yyaW2cih1jCqim0N1PgVGc1+k+QhIuHGpDVnAIcGXUywBk+JON5GQDkKP8QHyQ==
 
 scss-tokenizer@^0.2.3:
   version "0.2.3"
@@ -8356,6 +8572,11 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+typescript@^3.9.6:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+
 uc.micro@^1.0.1:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
@@ -8426,6 +8647,11 @@ unique-slug@^2.0.0:
   dependencies:
     imurmurhash "^0.1.4"
 
+universal-user-agent@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-6.0.0.tgz#3381f8503b251c0d9cd21bc1de939ec9df5480ee"
+  integrity sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==
+
 universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
@@ -8475,6 +8701,11 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
+
+url-join@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/url-join/-/url-join-4.0.1.tgz#b642e21a2646808ffa178c4c5fda39844e12cde7"
+  integrity sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==
 
 url-loader@^2.2.0:
   version "2.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -902,10 +902,10 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
-"@nestdotland/yolk@^0.2.0-rc1":
-  version "0.2.0-rc1"
-  resolved "https://registry.yarnpkg.com/@nestdotland/yolk/-/yolk-0.2.0-rc1.tgz#0599a3890aac8839605665703ec2f975b1fc071c"
-  integrity sha512-meOQFfvIoPRxl6TbMVHqnCo5Jd4sQ3/FNxprYIyy4UuScO/apg6tl0Da2JelfuNIPeMIY3bc61l7goK8nPejTw==
+"@nestdotland/yolk@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@nestdotland/yolk/-/yolk-0.3.0.tgz#4121768caf02618f6dd44d55288349572ac99440"
+  integrity sha512-AdXsRWjBhL/jhgC0TzpF35CSCq4B6G3VsN9P8JAH/axikkmz16VO81m8n5feRRL7luQog8w02st3ZndGxLuCAw==
   dependencies:
     denoify "^0.3.0"
     typescript "^3.9.6"
@@ -923,9 +923,9 @@
     "@octokit/types" "^5.0.0"
 
 "@octokit/core@^3.0.0":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@octokit/core/-/core-3.1.1.tgz#1856745aa8fb154cf1544a2a1b82586c809c5e66"
-  integrity sha512-cQ2HGrtyNJ1IBxpTP1U5m/FkMAJvgw7d2j1q3c9P0XUuYilEgF6e4naTpsgm4iVcQeOnccZlw7XHRIUBy0ymcg==
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@octokit/core/-/core-3.1.2.tgz#c937d5f9621b764573068fcd2e5defcc872fd9cc"
+  integrity sha512-AInOFULmwOa7+NFi9F8DlDkm5qtZVmDQayi7TUgChE3yeIGPq0Y+6cAEXPexQ3Ea+uZy66hKEazR7DJyU+4wfw==
   dependencies:
     "@octokit/auth-token" "^2.4.0"
     "@octokit/graphql" "^4.3.1"
@@ -944,9 +944,9 @@
     universal-user-agent "^6.0.0"
 
 "@octokit/graphql@^4.3.1":
-  version "4.5.3"
-  resolved "https://registry.yarnpkg.com/@octokit/graphql/-/graphql-4.5.3.tgz#d5ff0d4a8a33e98614a2a7359dac98bc285e062f"
-  integrity sha512-JyYvi3j2tOb5ofASEpcg1Advs07H+Ag+I+ez7buuZfNVAmh1IYcDTuxd4gnYH8S2PSGu+f5IdDGxMmkK+5zsdA==
+  version "4.5.4"
+  resolved "https://registry.yarnpkg.com/@octokit/graphql/-/graphql-4.5.4.tgz#c9ef75b0406ebf195bf5f4ed2304a77ed7df27c7"
+  integrity sha512-ITpZ+dQc0cXAW1FmDkHJJM+8Lb6anUnin0VB5hLBilnYVdLC0ICFU/KIvT7OXfW9S81DE3U4Vx2EypDG1OYaPA==
   dependencies:
     "@octokit/request" "^5.3.0"
     "@octokit/types" "^5.0.0"
@@ -1006,9 +1006,9 @@
     "@octokit/plugin-rest-endpoint-methods" "4.1.2"
 
 "@octokit/types@^5.0.0", "@octokit/types@^5.0.1", "@octokit/types@^5.1.1", "@octokit/types@^5.2.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-5.2.0.tgz#d075dc23bf293f540739250b6879e2c1be2fc20c"
-  integrity sha512-XjOk9y4m8xTLIKPe1NFxNWBdzA2/z3PFFA/bwf4EoH6oS8hM0Y46mEa4Cb+KCyj/tFDznJFahzQ0Aj3o1FYq4A==
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-5.4.0.tgz#25f2f8e24fec09214553168c41c06383c9d0f529"
+  integrity sha512-D/uotqF69M50OIlwMqgyIg9PuLT2daOiBAYF0P40I2ekFA2ESwwBY5dxZe/UhXdPvIbNKDzuZmQrO7rMpuFbcg==
   dependencies:
     "@types/node" ">= 8"
 
@@ -2565,9 +2565,9 @@ commander@~2.19.0:
   integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
 
 comment-json@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/comment-json/-/comment-json-3.0.2.tgz#a5652a491910e338080bcbf98fc9a37cbd7f3733"
-  integrity sha512-ysJasbJ671+8mPEmwLOfLFqxoGtSmjyoep+lKRVH4J1/hsGu79fwetMDQWk8de8mVgqDZ43D7JuJAlACqjI1pg==
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/comment-json/-/comment-json-3.0.3.tgz#0cadacd6278602b57b8c51b1814dc5d311d228c4"
+  integrity sha512-P7XwYkC3qjIK45EAa9c5Y3lR7SMXhJqwFdWg3niAIAcbk3zlpKDdajV8Hyz/Y3sGNn3l+YNMl8A2N/OubSArHg==
   dependencies:
     core-util-is "^1.0.2"
     esprima "^4.0.1"
@@ -3155,9 +3155,9 @@ delegates@^1.0.0:
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
 denoify@^0.3.0:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/denoify/-/denoify-0.3.3.tgz#f7d6d21f0ef754c05d12cd54793a554655adc4ed"
-  integrity sha512-QjaaOFYy8bOS9OoQo6nMR67VA0OYXZj1iwMxoH/SA6afFimqH96guN6Hu9d9oqwG8ZDBRVMW5YUwpMPTdlSITA==
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/denoify/-/denoify-0.3.8.tgz#4a91d5f3c476c29d75a74c7856cedd4b2b59111a"
+  integrity sha512-hK3z+Lhw3h2zW3BcjcRYFqfbLqMpFTZ1Ta9d7kN4vC4F5TlVPbw5F24WAiF7GbKi1qDaBaJ5RQEgJve6BqdsKA==
   dependencies:
     "@octokit/rest" "^18.0.0"
     "@types/comment-json" "^1.1.1"
@@ -3647,12 +3647,12 @@ evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
     safe-buffer "^5.1.1"
 
 evt@^1.7.13:
-  version "1.8.3"
-  resolved "https://registry.yarnpkg.com/evt/-/evt-1.8.3.tgz#720abd318b0bf680b5c734bd1276c1178ff076f5"
-  integrity sha512-3H60tAwOs20WMRbdzodq01cDKNv96ZCr0QKFdxwbkb3ZF+6rhS6eOOXQKdpxdlmJJ/8kIdlArvpdrwx1atBFpw==
+  version "1.8.7"
+  resolved "https://registry.yarnpkg.com/evt/-/evt-1.8.7.tgz#51f7b266f0aa9ff8b816f6e0e4b1d580b617eb9d"
+  integrity sha512-+yk8cryrCasrOGCWCmr+Q4MTp2/ujM1BGDL2zo73cI++gfxLDE8TvO0lL0NqKvURybcm485jQYakXOn0FeyLPg==
   dependencies:
-    minimal-polyfills "^2.1.3"
-    run-exclusive "^2.2.8"
+    minimal-polyfills "^2.1.4"
+    run-exclusive "^2.2.13"
 
 execa@^0.8.0:
   version "0.8.0"
@@ -5729,10 +5729,10 @@ mini-css-extract-plugin@^0.9.0:
     schema-utils "^1.0.0"
     webpack-sources "^1.1.0"
 
-minimal-polyfills@^2.1.3:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/minimal-polyfills/-/minimal-polyfills-2.1.3.tgz#de39bd2cbd18a549b60b6594f1dec602256a5798"
-  integrity sha512-gEbwv2dEvvrGys/hhWdZy+/BGkKAKqzxfmVqmF1Jl9OlD0tK9hEFLJ2tCXOuOtz2qiDMQO2Ke1jYB2s5uCj2Xw==
+minimal-polyfills@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/minimal-polyfills/-/minimal-polyfills-2.1.4.tgz#208d32410666dc8bcccee088646d52397b2be296"
+  integrity sha512-X4hfRfqGz+9f92hOy0kw4URE9TZEkmLDonLVXKETulK2Vjoo6ovBmVJkSGAgQX2fNIG3xZ9pW4V7+TWCQa8zFw==
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
@@ -7522,12 +7522,12 @@ run-async@^2.4.0:
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
   integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
 
-run-exclusive@^2.2.8:
-  version "2.2.8"
-  resolved "https://registry.yarnpkg.com/run-exclusive/-/run-exclusive-2.2.8.tgz#106854fff3f9a92a92a365dcaa1bee454e9bd4e0"
-  integrity sha512-WTSUO1p8eLiQGe1v0G1YsmrWt5pRZJHQu/Ql6KbTEqhivhctsyWNKGT+EEnek8l1We5Slm/lV2nqdup1m545Yg==
+run-exclusive@^2.2.13:
+  version "2.2.13"
+  resolved "https://registry.yarnpkg.com/run-exclusive/-/run-exclusive-2.2.13.tgz#778421aa10684fa6e8925a1e944fa3ab255589cf"
+  integrity sha512-88PHMS2WjLYSY2MjFvnq1QG5yTbWg+ePPwgY7UQF4gP2ALx2i3brwGyDs7fN7UMEuiLIJ0SMTQxpA42Vi07qtA==
   dependencies:
-    minimal-polyfills "^2.1.3"
+    minimal-polyfills "^2.1.4"
 
 run-queue@^1.0.0, run-queue@^1.0.3:
   version "1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -902,10 +902,10 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
-"@nestdotland/yolk@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@nestdotland/yolk/-/yolk-0.2.0.tgz#8ce0bacf42469ae31ec62aad8bc558c2666925f1"
-  integrity sha512-bTAMiM8CIH0u78g2V/ZeoDe79K+ivMBBQLmgRe8peJySwgbYTV7VcPxSS93EST5WxQYlDB1ZaHuc05ekptp8rg==
+"@nestdotland/yolk@^0.2.0-rc1":
+  version "0.2.0-rc1"
+  resolved "https://registry.yarnpkg.com/@nestdotland/yolk/-/yolk-0.2.0-rc1.tgz#0599a3890aac8839605665703ec2f975b1fc071c"
+  integrity sha512-meOQFfvIoPRxl6TbMVHqnCo5Jd4sQ3/FNxprYIyy4UuScO/apg6tl0Da2JelfuNIPeMIY3bc61l7goK8nPejTw==
   dependencies:
     denoify "^0.3.0"
     typescript "^3.9.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -902,10 +902,10 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
-"@nestdotland/yolk@^0.1.0-rc.3":
-  version "0.1.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@nestdotland/yolk/-/yolk-0.1.0-rc.3.tgz#8b42fb8eb47985d34080ff86161ff350aeb5524e"
-  integrity sha512-6qxCvHQM/XKiXIbYqqCaa+WeZZj/Fz5maxGCLgvBO6DHWfmarHgH/UiFobyx/q5vKUvRHj6sPYbDSKLHKKGURw==
+"@nestdotland/yolk@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@nestdotland/yolk/-/yolk-0.2.0.tgz#8ce0bacf42469ae31ec62aad8bc558c2666925f1"
+  integrity sha512-bTAMiM8CIH0u78g2V/ZeoDe79K+ivMBBQLmgRe8peJySwgbYTV7VcPxSS93EST5WxQYlDB1ZaHuc05ekptp8rg==
   dependencies:
     denoify "^0.3.0"
     typescript "^3.9.6"


### PR DESCRIPTION
**DO NOT MERGE**

Uses `yolk` to perform graphql queries with the new API

Did a quick gallery test and it works like charm:
![image](https://user-images.githubusercontent.com/34997667/89044214-4753fc00-d367-11ea-9eb0-25d756730fc0.png)
