### PR TITLE
add doc link at package detail page

### DIFF
--- a/src/views/PackageDetail.vue
+++ b/src/views/PackageDetail.vue
@@ -152,6 +152,19 @@
                     :icon="['fa', 'code-branch']"
                   />Repository
                 </a>
+                <a
+                  class="panel-block"
+                  :href="`https://doc.deno.land/${entryURL.replace(
+                    '://',
+                    '/'
+                  )}`"
+                  target="_blank"
+                >
+                  <font-awesome-icon
+                    class="icon-margin-right"
+                    :icon="['fa', 'book']"
+                  />Documentation
+                </a>
                 <router-link
                   v-if="!noVersion"
                   class="panel-block"


### PR DESCRIPTION
It links to "doc.deno.land" based on entry URL.