### PR TITLE
[BREAKING CHANGE] Remove eggs version helper

### DIFF
--- a/eggs/src/README.md
+++ b/eggs/src/README.md
@@ -1,6 +1,0 @@
-# What is this?
-
-eggs v0.1.8 mistakenly uses the raw.githubusercontent.com url for the file at `nestdotland/nest.land#master/eggs/src/version.ts`.
-As such to keep it from malfunctioning, the file must remain present here.
-This will change in a future release, where we are certain that eggs@0.1.8 is
-deprecated or doesn't work with the at the time.

--- a/eggs/src/version.ts
+++ b/eggs/src/version.ts
@@ -1,1 +1,0 @@
-export const version = "0.1.8";


### PR DESCRIPTION
Eggs `v0.1.8` is no longer supported by nest.land. Because of this, we are removing the eggs version helper, that was used to determinate the current version.