### PR TITLE
fix(Card.vue): Made Card component right-clickable

### DIFF
--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -6,13 +6,15 @@
     class="card"
     tag="div"
   >
-    <div class="card-content">
-      <div class="content">
-        <p class="title is-4">{{ item.name }}</p>
-        <hr class="mini-hr" />
-        <p class="subtitle is-6">{{ item.description }}</p>
+    <a>
+      <div class="card-content">
+        <div class="content">
+          <p class="title is-4">{{ item.name }}</p>
+          <hr class="mini-hr" />
+          <p class="subtitle is-6">{{ item.description }}</p>
+        </div>
       </div>
-    </div>
+    </a>
   </router-link>
 </template>
 


### PR DESCRIPTION
This PR enables right-clicking on any card component and opening it in a new tab like a regular `<a>` tag. I believe this should close #295. 